### PR TITLE
Cabal v2.0.0.2 was released

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 resolver: lts-7.0
-compiler: ghc-8.0.1
+compiler: ghc-8.0.2
 
 packages:
 - '.'
@@ -8,4 +8,4 @@ extra-deps:
 - libffi-0.1
 
 ghc-options:
-    sudbury: -lHSrts-ghc8.0.1
+    sudbury: -lHSrts-ghc8.0.2

--- a/sudbury.cabal
+++ b/sudbury.cabal
@@ -14,7 +14,7 @@ copyright:           Auke Booij, 2015-2017
 category:            Graphics
 build-type:          Simple
 extra-source-files:  README.md, cbits/wayland-msg-handling.h
-cabal-version:       >=1.25
+cabal-version:       >=2.0.0.2
 
 source-repository head
   type: git


### PR DESCRIPTION
https://github.com/haskell/cabal/releases/tag/Cabal-v2.0.0.2